### PR TITLE
Link libs statically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.idea.goland
+.idea.clion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
+cmake_minimum_required(VERSION 3.13)
 project(mosh-client)
 
-set(MOSH_SRC client/mosh-client/mosh-client.cpp
+set(LIB_MOSH_SRC client/mosh-client/junk.cpp 
                 client/mosh-client/stmclient.cpp
                 client/mosh-client/terminaloverlay.cpp
                 client/mosh-client/crypto/crypto.cc
@@ -32,6 +33,8 @@ set(MOSH_SRC client/mosh-client/mosh-client.cpp
                 client/mosh-client/util/mbrtowc_utf8
                 client/mosh-client/win32compat/tncon.cc)
 
+set(MOSH_SRC client/mosh-client/mosh-client.cpp)
+
 include_directories(client/mosh-client/win32compat)
 include_directories(client/mosh-client/statesync)
 include_directories(client/mosh-client/terminal)
@@ -42,6 +45,9 @@ include_directories(client/mosh-client/crypto)
 include_directories(client/mosh-client/protobufs)
 include_directories(client/mosh-client/openssl-1.1.1b-win64-mingw/include)
 
+add_library(libmoshclient STATIC ${LIB_MOSH_SRC})
 add_executable(${PROJECT_NAME} ${MOSH_SRC})
+
 target_link_libraries(${PROJECT_NAME} -L${PROJECT_SOURCE_DIR}/libs)
-target_link_libraries(${PROJECT_NAME} -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz)
+target_link_libraries(${PROJECT_NAME} libmoshclient)
+target_link_libraries(${PROJECT_NAME} -static -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz)

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ mosh-client:
         -I client/mosh-client/crypto \
         -I client/mosh-client/protobufs \
         -I client/mosh-client/openssl-1.1.1b-win64-mingw/include \
-            -L libs -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz
+            -L libs -static -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz

--- a/client/c_mosh_client.go
+++ b/client/c_mosh_client.go
@@ -1,6 +1,12 @@
 package client
 
-/*
-
-*/
+// #cgo CFLAGS: -IE:/Projects/GO/src/github.com/jumptrading/mosh-go/client/mosh-client/
+// #cgo LDFLAGS: E:/Projects/GO/src/github.com/jumptrading/mosh-go/cmake-build-debug-mingw/liblibmoshclient.a
+// #include <junk.h>
 import "C"
+
+
+func Rrr() error {
+	C.x(42)
+	return nil
+}

--- a/client/mosh-client/junk.cpp
+++ b/client/mosh-client/junk.cpp
@@ -1,0 +1,8 @@
+#include <cstdio>
+#include "junk.h"
+
+int x(int y) {
+   printf("Hello World %d times\n", y);
+   return y;
+}
+

--- a/client/mosh-client/junk.h
+++ b/client/mosh-client/junk.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" { 
+#endif
+
+int x(int y);
+
+#ifdef __cplusplus
+} 
+#endif

--- a/client/mosh-client/util/select.h
+++ b/client/mosh-client/util/select.h
@@ -76,18 +76,54 @@ typedef int sigset_t;
 int w32_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
 #define sigprocmask(a,b,c) w32_sigprocmask((a), (b), (c))
 
+#ifndef SIGINT
 #define SIGINT	W32_SIGINT
+#endif
+
+#ifndef SIGSEGV
 #define SIGSEGV	W32_SIGSEGV
+#endif
+
+#ifndef SIGPIPE
 #define SIGPIPE	W32_SIGPIPE
+#endif
+
+#ifndef SIGCHLD
 #define SIGCHLD	W32_SIGCHLD
+#endif
+
+#ifndef SIGALRM
 #define SIGALRM	W32_SIGALRM
+#endif
+
+#ifndef SIGTSTP
 #define SIGTSTP	W32_SIGTSTP
+#endif
+
+#ifndef SIGHUP
 #define SIGHUP	W32_SIGHUP
+#endif
+
+#ifndef SIGQUIT
 #define SIGQUIT	W32_SIGQUIT
+#endif
+
+#ifndef SIGTERM
 #define SIGTERM	W32_SIGTERM
+#endif
+
+#ifndef SIGTTIN
 #define SIGTTIN	W32_SIGTTIN
+#endif
+
+#ifndef SIGTTOU
 #define SIGTTOU	W32_SIGTTOU
+#endif
+
+#ifndef SIGWINCH
 #define SIGWINCH W32_SIGWINCH
+#endif
+
 
 /* Convenience wrapper for pselect(2).
 

--- a/mosh.go
+++ b/mosh.go
@@ -21,11 +21,14 @@ import (
 	"golang.org/x/net/proxy"
 
 	"github.com/artyom/autoflags"
-	"runtime"
+	"github.com/jumptrading/mosh-go/client"
 	"path/filepath"
+	"runtime"
 )
 
 func main() {
+	client.Rrr()
+
 	defaultUser := os.Getenv("MOSH_USER")
 	if defaultUser == "" {
 		defaultUser = os.Getenv("USER")
@@ -67,7 +70,6 @@ func main() {
 	os.Setenv("MOSH_KEY", key)
 	os.Setenv("MOSH_PREDICTION_DISPLAY", "adaptive")
 
-
 	if runtime.GOOS == "windows" {
 		executableFullPathName, err := os.Executable()
 		if err != nil {
@@ -81,7 +83,7 @@ func main() {
 
 		attrs := &os.ProcAttr{
 			Env: os.Environ(),
-			Files: []*os.File {
+			Files: []*os.File{
 				os.Stdin,
 				os.Stdout,
 				os.Stderr,


### PR DESCRIPTION
This PR adds the ability to compile the whole `mosh_client` as a static library so it can potentially be linked into other executable (say, the `mosh-go` itself).

The `junk.h` is the sample header, and the `junk.cpp` is the sample place for interface functions which can be called from Go code.