### PR TITLE
Call the statically linked mosh_client from Go code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(mosh-client)
 
-set(LIB_MOSH_SRC client/mosh-client/junk.cpp 
+set(LIB_MOSH_SRC client/mosh-client/libinterface.cpp
                 client/mosh-client/stmclient.cpp
                 client/mosh-client/terminaloverlay.cpp
                 client/mosh-client/crypto/crypto.cc
@@ -45,9 +45,9 @@ include_directories(client/mosh-client/crypto)
 include_directories(client/mosh-client/protobufs)
 include_directories(client/mosh-client/openssl-1.1.1b-win64-mingw/include)
 
-add_library(libmoshclient STATIC ${LIB_MOSH_SRC})
+add_library(moshclient STATIC ${LIB_MOSH_SRC})
 add_executable(${PROJECT_NAME} ${MOSH_SRC})
 
 target_link_libraries(${PROJECT_NAME} -L${PROJECT_SOURCE_DIR}/libs)
-target_link_libraries(${PROJECT_NAME} libmoshclient)
+target_link_libraries(${PROJECT_NAME} moshclient)
 target_link_libraries(${PROJECT_NAME} -static -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz)

--- a/client/c_mosh_client.go
+++ b/client/c_mosh_client.go
@@ -1,12 +1,49 @@
 package client
 
-// #cgo CFLAGS: -IE:/Projects/GO/src/github.com/jumptrading/mosh-go/client/mosh-client/
-// #cgo LDFLAGS: E:/Projects/GO/src/github.com/jumptrading/mosh-go/cmake-build-debug-mingw/liblibmoshclient.a
-// #include <junk.h>
+// #cgo CFLAGS: -I./mosh-client/
+// #cgo LDFLAGS: -L../libs -lmoshclient -lprotobuf -lprotobuf-lite -lprotoc -lcrypto -lssl -pthread -lpthread -lws2_32 -lz -lstdc++ -lm
+// #include <stdlib.h>
+// #include <libinterface.h>
 import "C"
+import (
+	"fmt"
+	"unsafe"
+)
 
+func StartMoshClient(ip string, desiredPort string, key string, predictMode string, verbose bool, predictOverwrite string) error {
 
-func Rrr() error {
-	C.x(42)
+	c_ip := C.CString(ip)
+	c_desiredPort := C.CString(desiredPort)
+	c_key := C.CString(key)
+
+	defer func() {
+		C.free(unsafe.Pointer(c_key))
+		C.free(unsafe.Pointer(c_desiredPort))
+		C.free(unsafe.Pointer(c_ip))
+	}()
+
+	var c_predictMode *C.char
+	if len(predictMode) != 0 {
+		c_predictMode = C.CString(predictMode)
+		defer C.free(unsafe.Pointer(c_predictMode))
+	}
+
+	var c_predictOverwrite *C.char
+	if len(predictOverwrite) != 0 {
+		c_predictOverwrite = C.CString(predictOverwrite)
+		defer C.free(unsafe.Pointer(c_predictOverwrite))
+	}
+
+	c_verbose := C.int(0)
+	if verbose {
+		c_verbose = C.int(1)
+	}
+
+	result := C.startMoshClient(c_ip, c_desiredPort, c_key, c_predictMode, c_verbose, c_predictOverwrite)
+
+	if result == 0 {
+		return fmt.Errorf("Mosh client error")
+	}
+
 	return nil
 }

--- a/client/mosh-client/junk.cpp
+++ b/client/mosh-client/junk.cpp
@@ -1,8 +1,0 @@
-#include <cstdio>
-#include "junk.h"
-
-int x(int y) {
-   printf("Hello World %d times\n", y);
-   return y;
-}
-

--- a/client/mosh-client/junk.h
+++ b/client/mosh-client/junk.h
@@ -1,9 +1,0 @@
-#ifdef __cplusplus
-extern "C" { 
-#endif
-
-int x(int y);
-
-#ifdef __cplusplus
-} 
-#endif

--- a/client/mosh-client/libinterface.cpp
+++ b/client/mosh-client/libinterface.cpp
@@ -1,0 +1,82 @@
+#include <cstdio>
+#include <fatal_assert.h>
+#include <locale_utils.h>
+
+#include "libinterface.h"
+#include "stmclient.h"
+
+void setupConsole() {
+    HANDLE hInput = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD dwInputMode;
+
+    GetConsoleMode(hInput, &dwInputMode);
+
+    dwInputMode &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_MOUSE_INPUT);
+    dwInputMode |= ENABLE_WINDOW_INPUT;
+
+    if( !SetConsoleMode(hInput, dwInputMode) ) {
+        fatal_assert(!"SetConsoleMode() error");
+        exit(1);
+    }
+
+    HANDLE hOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD dwOutputMode;
+
+    GetConsoleMode(hOutput, &dwOutputMode);
+    dwOutputMode |= 0x0004 | 0x0008;
+    if( !SetConsoleMode(hOutput, dwOutputMode) ) {
+        fatal_assert(!"SetConsoleMode() error");
+        exit(1);
+    }
+}
+
+/**
+ *
+ * @param ip                bind to this IP
+ * @param desiredPort       bind to this port
+ * @param key               MOSH_KEY
+ * @param predictMode       "always" | "never" | "adaptive" | "experimental" | NULL
+ * @param verbose
+ * @param predictOverwrite  "yes" | NULL
+ *
+ * @return
+ */
+int startMoshClient(char *ip, char *desiredPort, char *key, char *predictMode, int verbose, char *predictOverwrite) {
+
+    setupConsole();
+
+    /* For security, make sure we don't dump core */
+    Crypto::disable_dumping_core();
+
+    /* Adopt native locale */
+    set_native_locale();
+
+    bool success = false;
+    try {
+        STMClient client(ip, desiredPort, key, predictMode, verbose, predictOverwrite);
+        client.init();
+
+        try {
+            success = client.main();
+        } catch (...) {
+            client.shutdown();
+            throw;
+        }
+
+        client.shutdown();
+    } catch( const Network::NetworkException &e ) {
+        fprintf(stderr, "Network exception: %s\r\n", e.what());
+        success = false;
+    } catch( const Crypto::CryptoException &e ) {
+        fprintf(stderr, "Crypto exception: %s\r\n", e.what());
+        success = false;
+    } catch( const std::exception &e ) {
+        fprintf(stderr, "Error: %s\r\n", e.what());
+        success = false;
+    }
+
+    printf( "[mosh is exiting.]\n" );
+
+    return !success;
+}
+

--- a/client/mosh-client/libinterface.h
+++ b/client/mosh-client/libinterface.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" { 
+#endif
+
+int startMoshClient(char *ip, char *desiredPort, char *key, char *predictMode, int verbose, char *predictOverwrite);
+
+#ifdef __cplusplus
+} 
+#endif


### PR DESCRIPTION
Now the `mosh-go` code calls mosh client which is statically linked into the executable. So, the only executable needed to establish mosh connection is `mosh-go` (it does not need even OpenSSH). By the way, `mosh-go` can run in plain old console windows, not only in terminal emulators such as Aminal or FluentTerminal.

**Note on Build**
1. First build `mosh-client` using `cmake` (the `Makefile` build has not been updated). After that, copy the resulting static library `libmoshclient.a` to the `libs` directory.
2. Then build `mosh-go`:
    - `go clean -cache`
    - `go build`

Fixes #3 and #5 