### PR TITLE
Fix handling of user input events

### DIFF
--- a/client/mosh-client/network/network.h
+++ b/client/mosh-client/network/network.h
@@ -75,7 +75,7 @@ namespace Network {
   public:
       WSAException(string s_function, int wsaError) : NetworkException(s_function, 0) {
           //TODO: use FormatMessage() to get correct error message
-          my_what = function + ": " + std::to_string(wsaError);
+          my_what = function + ": Error " + std::to_string(wsaError);
       }
   };
 

--- a/client/mosh-client/stmclient.cpp
+++ b/client/mosh-client/stmclient.cpp
@@ -491,16 +491,12 @@ bool STMClient::main( void )
 
       /* poll for events */
       /* network->fd() can in theory change over time */
-      sel.clear_fds();
+      sel.clear_handles();
       std::vector< int > fd_list( network->fds() );
-      for ( std::vector< int >::const_iterator it = fd_list.begin();
-        it != fd_list.end();
-        it++ ) {
-        sel.add_fd( *it );
+      for ( std::vector< int >::const_iterator it = fd_list.begin(); it != fd_list.end(); it++ ) {
+          sel.add_socket(*it);
       }
-      //sel.add_fd( STDIN_FILENO );
-      DWORD inputEventCount = 0;
-      GetNumberOfConsoleInputEvents(inputHandle, &inputEventCount);
+      sel.add_waitable_handle( inputHandle );
 
       int active_fds = sel.select( wait_time );
       if ( active_fds < 0 ) {
@@ -513,7 +509,7 @@ bool STMClient::main( void )
       for ( std::vector< int >::const_iterator it = fd_list.begin();
         it != fd_list.end();
         it++ ) {
-        if ( sel.read( *it ) ) {
+        if ( sel.isSocketReady( *it ) ) {
           /* packet received from the network */
           /* we only read one socket each run */
           network_ready_to_read = true;
@@ -524,17 +520,15 @@ bool STMClient::main( void )
         process_network_input();
       }
 
+      DWORD inputEventCount = 0;
+      GetNumberOfConsoleInputEvents(inputHandle, &inputEventCount);
       if ( inputEventCount && !process_user_input()/*sel.read( STDIN_FILENO ) && !process_user_input( STDIN_FILENO )*/ ) { // input from the user needs to be fed to the network
-        if ( !network->has_remote_addr() ) {
-          break;
-        } else if ( !network->shutdown_in_progress() ) {
-          overlays.get_notification_engine().set_notification_string( wstring( L"Exiting..." ), true );
-          network->start_shutdown();
-        }
-      }
-
-      if ( sel.signal( SIGWINCH ) && !process_resize() ) { /* resize */
-        return false;
+          if (!network->has_remote_addr()) {
+              break;
+          } else if (!network->shutdown_in_progress()) {
+              overlays.get_notification_engine().set_notification_string(wstring(L"Exiting..."), true);
+              network->start_shutdown();
+          }
       }
 
       /*if ( sel.signal( SIGCONT ) ) {

--- a/client/mosh-client/util/select.cc
+++ b/client/mosh-client/util/select.cc
@@ -32,8 +32,6 @@
 
 #include "select.h"
 
-fd_set Select::dummy_fd_set;
-
 sigset_t Select::dummy_sigset;
 
 unsigned int Select::verbose = 0;

--- a/client/mosh-client/win32compat/tncon.cc
+++ b/client/mosh-client/win32compat/tncon.cc
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <windows.h>
+#include <wincon.h>
 //#include "ansiprsr.h"
 #include "tncon.h"
 //#include "tnnet.h"
@@ -212,16 +213,23 @@ ReadConsoleForTermEmul(HANDLE hInput, char *destin, int destinlen, const std::fu
 
 			modKey = GetModifierKey(dwControlKeyState);
 			if (InputRecord.Event.KeyEvent.bKeyDown) {
-				int n = WideCharToMultiByte(
-					CP_UTF8,
-					0,
-					&(InputRecord.Event.KeyEvent.uChar.UnicodeChar),
-					1,
-					(LPSTR)octets,
-					20,
-					NULL,
-					NULL);
+			    int n;
 
+			    if( (dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) != 0 && InputRecord.Event.KeyEvent.wVirtualKeyCode == 0x36 ) {
+                                // handle Ctrl+^
+                                *octets = '\x1E';
+                                n = 1;
+                            } else {
+                                n = WideCharToMultiByte(
+                                        CP_UTF8,
+                                        0,
+                                        &(InputRecord.Event.KeyEvent.uChar.UnicodeChar),
+                                        1,
+                                        (LPSTR) octets,
+                                        20,
+                                        NULL,
+                                        NULL);
+                            }
                 //if (pParams->fLocalEcho)
                 //	ConWriteString((char *)octets, n);
 
@@ -800,7 +808,7 @@ ReadConsoleForTermEmul(HANDLE hInput, char *destin, int destinlen, const std::fu
 							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF12_KEY, strlen(SHIFT_CTRL_PF12_KEY), 0);
 						break;
 					default:
-						if (strcmp((char *) octets, "")) {
+						if(n > 0) { //(strcmp((char *) octets, "")) {
 							if ((dwControlKeyState & LEFT_ALT_PRESSED) || (dwControlKeyState & RIGHT_ALT_PRESSED)) {								
 								memset(tmp_buf, 0, sizeof(tmp_buf));
 								tmp_buf[0] = '\x1b';


### PR DESCRIPTION
On Linux, the `select()` function is used to wait on any type of descriptor, because of the _everything is a file_ principle. `mosh` uses this approach to wait on sockets _and_ on the standard input within the same call to `select()`.
On Windows, `select()` can be used to wait on sockets only - passing `STDIN` handle to that function will not work. That's why user input was not handled correctly on windows, especially handling of the `mosh` escape sequences (_Ctrl+^_ etc.)

This PR fixes the handling of user input events.

Fixes #18 